### PR TITLE
Fix prometheus webhook

### DIFF
--- a/prometheus/kube-prometheus-stack.values
+++ b/prometheus/kube-prometheus-stack.values
@@ -1605,7 +1605,7 @@ prometheusOperator:
   ## Prometheus-Operator v0.39.0 and later support TLS natively.
   ##
   tls:
-    enabled: true
+    enabled: false
     # Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants
     tlsMinVersion: VersionTLS13
     # The default webhook port is 10250 in order to work out-of-the-box in GKE private clusters and avoid adding firewall rules.

--- a/prometheus/kube-prometheus-stack.values
+++ b/prometheus/kube-prometheus-stack.values
@@ -1617,7 +1617,7 @@ prometheusOperator:
     failurePolicy: Fail
     ## The default timeoutSeconds is 10 and the maximum value is 30.
     timeoutSeconds: 10
-    enabled: true
+    enabled: false
     ## A PEM encoded CA bundle which will be used to validate the webhook's server certificate.
     ## If unspecified, system trust roots on the apiserver are used.
     caBundle: ""

--- a/prometheus/kube-prometheus-stack.values
+++ b/prometheus/kube-prometheus-stack.values
@@ -1605,7 +1605,7 @@ prometheusOperator:
   ## Prometheus-Operator v0.39.0 and later support TLS natively.
   ##
   tls:
-    enabled: false
+    enabled: true
     # Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants
     tlsMinVersion: VersionTLS13
     # The default webhook port is 10250 in order to work out-of-the-box in GKE private clusters and avoid adding firewall rules.


### PR DESCRIPTION
Fix error:
Internal error occurred: failed calling webhook "prometheusrulemutate.monitoring.coreos.com": failed to call webhook: Post "https://kube-prometheus-stack-1673-operator.prometheus.svc:443/admission-prometheusrules/mutate?timeout=10s": dial tcp 10.43.132.23:443: connect: connection refused